### PR TITLE
use alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.8
 
 RUN apk update  \
  && apk add     \


### PR DESCRIPTION
use alpine 3.8 due to incompatibilty with opensll package in alpine 3.9